### PR TITLE
Resolving bokeh keyword problem in host name. Issue #1775

### DIFF
--- a/bokehjs/src/coffee/common/base.coffee
+++ b/bokehjs/src/coffee/common/base.coffee
@@ -171,7 +171,7 @@ define [
   Config = {}
   url = window.location.href
   if url.indexOf('/bokeh') > 0
-    Config.prefix = url.slice(0, url.indexOf('/bokeh')) + "/" #keep trailing slash
+    Config.prefix = url.slice(0, url.lastIndexOf('/bokeh')) + "/" #keep trailing slash
   else
     Config.prefix = '/'
   console.log('Bokeh: setting prefix to', Config.prefix)


### PR DESCRIPTION
If the bokeh-server host name contains `bokeh` keywork `Config.prefix` value is not the expected value.
For example if the url is `http://bokeh-test.com/bokeh/` the `Config.prefix` value will be `http:/` while the expected value is `http://bokeh-test.com`. It Fixes #1775.